### PR TITLE
Always more bugfixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "godot_tools.editor_path": "d:\\Godot\\Godot_v4.0-beta3_win64.exe\\Godot_v4.0-beta3_win64.exe"
-}

--- a/Fight/Scripts/combattant.gd
+++ b/Fight/Scripts/combattant.gd
@@ -278,7 +278,7 @@ func check_tacle_unit(case: Vector2i) -> bool:
 	var voisins = [Vector2i(-1, 0), Vector2i(1, 0), Vector2i(0, -1), Vector2i(0, 1)]
 	var blocage_total = 0
 	for combattant in combat.combattants:
-		if combattant.equipe == equipe or combattant.check_etats(["PORTE"]):
+		if combattant.equipe == equipe or combattant.check_etats(["PORTE", "PETRIFIE"]):
 			continue
 		if (combattant.grid_pos - case) in voisins:
 			blocage_total += combattant.stats.blocage
@@ -416,6 +416,8 @@ func execute_effets():
 
 
 func check_etats(etats: Array) -> bool:
+	if "VIE_FAIBLE" in etats and stats.hp < max_stats.hp / 4:
+		return true
 	for effet in effets:
 		if effet.etat in etats:
 			return true

--- a/Fight/Scripts/combattant.gd
+++ b/Fight/Scripts/combattant.gd
@@ -284,7 +284,9 @@ func check_tacle_unit(case: Vector2i) -> bool:
 			continue
 		if (combattant.grid_pos - case) in voisins:
 			blocage_total += combattant.stats.blocage
-	if randi_range(max(stats.esquive - 99, 1), max(stats.esquive, 2)) < blocage_total:
+	var min_esquive = max(stats.esquive - 99, 1)
+	var max_esquive = max(stats.esquive, 2)
+	if randi_range(min_esquive, max_esquive) < blocage_total:
 		return true
 	return false
 
@@ -418,7 +420,7 @@ func execute_effets():
 
 
 func check_etats(etats: Array) -> bool:
-	if "VIE_FAIBLE" in etats and stats.hp < max_stats.hp / 4:
+	if "VIE_FAIBLE" in etats and stats.hp < int(max_stats.hp / 4):
 		return true
 	for effet in effets:
 		if effet.etat in etats:

--- a/Fight/Scripts/combattant.gd
+++ b/Fight/Scripts/combattant.gd
@@ -263,13 +263,15 @@ func joue_action(action: int, tile_pos: Vector2i):
 						effet.execute()
 			if not is_invocation:
 				combat.sorts.update(self)
-			combat.tilemap.grid[grid_pos[0]][grid_pos[1]] = -2
-			retire_etats(["INVISIBLE"])
+			if tile_pos != grid_pos or not sort.effets.has("DEVIENT_INVISIBLE"):
+				combat.tilemap.grid[grid_pos[0]][grid_pos[1]] = -2
+				retire_etats(["INVISIBLE"])
 			if grid_pos != tile_pos:
 				oriente_vers(tile_pos)
 		combat.change_action(7)
 	combat.stats_select.update(stats)
 	combat.check_morts()
+	combat.tilemap.affiche_ldv_obstacles()
 
 
 func affiche_stats_change(valeur, stat):

--- a/Fight/Scripts/combattant.gd
+++ b/Fight/Scripts/combattant.gd
@@ -172,9 +172,11 @@ func check_case_bonus():
 	var categorie = ""
 	var contenu = ""
 	var maudit = false
-	for case in combat.tilemap.cases_maudites.values():
-		if case == grid_pos:
-			maudit = true
+	if grid_pos in combat.tilemap.cases_maudites.values():
+		maudit = true
+#	for case in combat.tilemap.cases_maudites.values():
+#		if case == grid_pos:
+#			maudit = true
 	match case_id:
 		2:
 			categorie = "CHANGE_STATS"
@@ -282,7 +284,7 @@ func check_tacle_unit(case: Vector2i) -> bool:
 			continue
 		if (combattant.grid_pos - case) in voisins:
 			blocage_total += combattant.stats.blocage
-	if randi_range(1, stats.esquive if stats.esquive > 1 else 2) < blocage_total:
+	if randi_range(max(stats.esquive - 99, 1), max(stats.esquive, 2)) < blocage_total:
 		return true
 	return false
 

--- a/Fight/Scripts/effet.gd
+++ b/Fight/Scripts/effet.gd
@@ -317,6 +317,8 @@ func dommage_fixe():
 		applique_dommage(contenu[base_crit]["allies"], 0.0, 0.0, false, "normal")
 	elif contenu[base_crit].has("invocations") and cible.is_invocation: 
 		applique_dommage(contenu[base_crit]["invocations"], 0.0, 0.0, false, "normal")
+	elif contenu[base_crit].has("maudit") and centre in combat.tilemap.cases_maudites.values():
+		applique_dommage(contenu[base_crit]["maudit"], 0.0, 0.0, false, "normal")
 	elif contenu[base_crit].has("valeur"):
 		applique_dommage(contenu[base_crit]["valeur"], 0.0, 0.0, false, "normal")
 	if contenu[base_crit].has("retour"):

--- a/Fight/Scripts/effet.gd
+++ b/Fight/Scripts/effet.gd
@@ -298,9 +298,9 @@ func applique_dommage(base, stat, resistance, orientation_bonus, type):
 	cible.stats_perdu.ajoute(-dommages, "hp")
 	print(cible.classe, "_", str(cible.id), " perd " if dommages >= 0 else " gagne ", dommages, " PdV.")
 	
-	lanceur.stats.hp -= dommages * (cible.stats.renvoi_dommage / 100)
+	lanceur.stats.hp -= dommages * (cible.stats.renvoi_dommage / 100.0)
 	if cible.stats.renvoi_dommage > 0:
-		lanceur.stats_perdu.ajoute(-dommages * (cible.stats.renvoi_dommage / 100), "hp")
+		lanceur.stats_perdu.ajoute(-dommages * (cible.stats.renvoi_dommage / 100.0), "hp")
 		print(lanceur.classe, "_", str(lanceur.id), " perd ", dommages, " PdV.")
 	
 	if type == "vol":
@@ -764,8 +764,9 @@ func rate_sort():
 
 func revele_invisible():
 	for combattant in combat.combattants:
-		combat.tilemap.grid[combattant.grid_pos[0]][combattant.grid_pos[1]] = -2
-		combattant.retire_etats(["INVISIBLE"])
+		if combattant.id != lanceur.id:
+			combat.tilemap.grid[combattant.grid_pos[0]][combattant.grid_pos[1]] = -2
+			combattant.retire_etats(["INVISIBLE"])
 	print(cible.classe, "_", str(cible.id), " révèle les invisibles.")
 
 

--- a/Fight/Scripts/sorts_selection.gd
+++ b/Fight/Scripts/sorts_selection.gd
@@ -41,7 +41,7 @@ func update(combattant):
 			texture_rect.add_child(carte)
 			
 			texture_rect.connect("mouse_entered", sort_hovered.bind(texture_rect, sort_id))
-			texture_rect.connect("mouse_exited", sort_exited.bind(texture_rect, sort_id))
+			texture_rect.connect("mouse_exited", sort_exited.bind(texture_rect))
 			sort_id += 1
 
 
@@ -50,7 +50,7 @@ func sort_hovered(sort, sort_id):
 	carte_hovered = sort_id
 
 
-func sort_exited(sort, sort_id):
+func sort_exited(sort):
 	sort.get_node("carte").visible = false
 	carte_hovered = -1
 

--- a/Fight/affichage_stats_small.tscn
+++ b/Fight/affichage_stats_small.tscn
@@ -14,6 +14,7 @@ texture = ExtResource("1_i74ii")
 script = ExtResource("2_tkitm")
 
 [node name="Stats" type="HBoxContainer" parent="."]
+layout_mode = 0
 offset_left = 8.0
 offset_top = 11.0
 offset_right = 48.0
@@ -22,9 +23,7 @@ theme_override_constants/separation = 15
 
 [node name="HP" type="Label" parent="Stats"]
 custom_minimum_size = Vector2(28, 26)
-offset_top = 7.0
-offset_right = 28.0
-offset_bottom = 33.0
+layout_mode = 2
 text = "0"
 label_settings = SubResource("LabelSettings_chl8o")
 horizontal_alignment = 1
@@ -32,10 +31,7 @@ vertical_alignment = 1
 
 [node name="PA" type="Label" parent="Stats"]
 custom_minimum_size = Vector2(28, 26)
-offset_left = 43.0
-offset_top = 7.0
-offset_right = 71.0
-offset_bottom = 33.0
+layout_mode = 2
 text = "0"
 label_settings = SubResource("LabelSettings_chl8o")
 horizontal_alignment = 1
@@ -43,10 +39,7 @@ vertical_alignment = 1
 
 [node name="PM" type="Label" parent="Stats"]
 custom_minimum_size = Vector2(28, 26)
-offset_left = 86.0
-offset_top = 7.0
-offset_right = 114.0
-offset_bottom = 33.0
+layout_mode = 2
 text = "0"
 label_settings = SubResource("LabelSettings_chl8o")
 horizontal_alignment = 1

--- a/Fight/combattant.tscn
+++ b/Fight/combattant.tscn
@@ -7,9 +7,9 @@
 [ext_resource type="Texture2D" uid="uid://di4dh5dwn3exu" path="res://Fight/Images/hp_display.png" id="5_o5476"]
 [ext_resource type="PackedScene" uid="uid://wjqjfqvfle7s" path="res://Fight/stats_perdu.tscn" id="6_xhp4k"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_nbwcr"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_6fhlc"]
 
-[sub_resource type="LabelSettings" id="LabelSettings_8fnai"]
+[sub_resource type="LabelSettings" id="LabelSettings_4dhpp"]
 font_size = 25
 
 [node name="Combattant" type="Node2D"]
@@ -32,7 +32,7 @@ position = Vector2(0, -38)
 scale = Vector2(2, 4)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-shape = SubResource("RectangleShape2D_nbwcr")
+shape = SubResource("RectangleShape2D_6fhlc")
 
 [node name="HP" type="Sprite2D" parent="."]
 visible = false
@@ -48,7 +48,7 @@ offset_top = -18.0
 offset_right = 49.0
 offset_bottom = 20.0
 text = "0/0"
-label_settings = SubResource("LabelSettings_8fnai")
+label_settings = SubResource("LabelSettings_4dhpp")
 horizontal_alignment = 1
 vertical_alignment = 1
 

--- a/Fight/combattant.tscn
+++ b/Fight/combattant.tscn
@@ -7,9 +7,9 @@
 [ext_resource type="Texture2D" uid="uid://di4dh5dwn3exu" path="res://Fight/Images/hp_display.png" id="5_o5476"]
 [ext_resource type="PackedScene" uid="uid://wjqjfqvfle7s" path="res://Fight/stats_perdu.tscn" id="6_xhp4k"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_6fhlc"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_gtfac"]
 
-[sub_resource type="LabelSettings" id="LabelSettings_4dhpp"]
+[sub_resource type="LabelSettings" id="LabelSettings_7kwjs"]
 font_size = 25
 
 [node name="Combattant" type="Node2D"]
@@ -32,7 +32,7 @@ position = Vector2(0, -38)
 scale = Vector2(2, 4)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-shape = SubResource("RectangleShape2D_6fhlc")
+shape = SubResource("RectangleShape2D_gtfac")
 
 [node name="HP" type="Sprite2D" parent="."]
 visible = false
@@ -48,7 +48,7 @@ offset_top = -18.0
 offset_right = 49.0
 offset_bottom = 20.0
 text = "0/0"
-label_settings = SubResource("LabelSettings_4dhpp")
+label_settings = SubResource("LabelSettings_7kwjs")
 horizontal_alignment = 1
 vertical_alignment = 1
 

--- a/Fight/combattant.tscn
+++ b/Fight/combattant.tscn
@@ -7,9 +7,9 @@
 [ext_resource type="Texture2D" uid="uid://di4dh5dwn3exu" path="res://Fight/Images/hp_display.png" id="5_o5476"]
 [ext_resource type="PackedScene" uid="uid://wjqjfqvfle7s" path="res://Fight/stats_perdu.tscn" id="6_xhp4k"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_gtfac"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_3veq3"]
 
-[sub_resource type="LabelSettings" id="LabelSettings_7kwjs"]
+[sub_resource type="LabelSettings" id="LabelSettings_8tva6"]
 font_size = 25
 
 [node name="Combattant" type="Node2D"]
@@ -32,7 +32,7 @@ position = Vector2(0, -38)
 scale = Vector2(2, 4)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-shape = SubResource("RectangleShape2D_gtfac")
+shape = SubResource("RectangleShape2D_3veq3")
 
 [node name="HP" type="Sprite2D" parent="."]
 visible = false
@@ -48,7 +48,7 @@ offset_top = -18.0
 offset_right = 49.0
 offset_bottom = 20.0
 text = "0/0"
-label_settings = SubResource("LabelSettings_7kwjs")
+label_settings = SubResource("LabelSettings_8tva6")
 horizontal_alignment = 1
 vertical_alignment = 1
 

--- a/Fight/combattant.tscn
+++ b/Fight/combattant.tscn
@@ -7,9 +7,9 @@
 [ext_resource type="Texture2D" uid="uid://di4dh5dwn3exu" path="res://Fight/Images/hp_display.png" id="5_o5476"]
 [ext_resource type="PackedScene" uid="uid://wjqjfqvfle7s" path="res://Fight/stats_perdu.tscn" id="6_xhp4k"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_pno81"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_nbwcr"]
 
-[sub_resource type="LabelSettings" id="LabelSettings_cbdmk"]
+[sub_resource type="LabelSettings" id="LabelSettings_8fnai"]
 font_size = 25
 
 [node name="Combattant" type="Node2D"]
@@ -32,7 +32,7 @@ position = Vector2(0, -38)
 scale = Vector2(2, 4)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-shape = SubResource("RectangleShape2D_pno81")
+shape = SubResource("RectangleShape2D_nbwcr")
 
 [node name="HP" type="Sprite2D" parent="."]
 visible = false
@@ -48,7 +48,7 @@ offset_top = -18.0
 offset_right = 49.0
 offset_bottom = 20.0
 text = "0/0"
-label_settings = SubResource("LabelSettings_cbdmk")
+label_settings = SubResource("LabelSettings_8fnai")
 horizontal_alignment = 1
 vertical_alignment = 1
 

--- a/Fight/invocation.tscn
+++ b/Fight/invocation.tscn
@@ -7,9 +7,9 @@
 [ext_resource type="Texture2D" uid="uid://di4dh5dwn3exu" path="res://Fight/Images/hp_display.png" id="5_eb3vf"]
 [ext_resource type="PackedScene" uid="uid://wjqjfqvfle7s" path="res://Fight/stats_perdu.tscn" id="6_aopma"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_6tol3"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_ptml5"]
 
-[sub_resource type="LabelSettings" id="LabelSettings_eb617"]
+[sub_resource type="LabelSettings" id="LabelSettings_fwvgu"]
 font_size = 25
 
 [node name="Invocation" type="Node2D"]
@@ -30,7 +30,7 @@ position = Vector2(0, -10)
 scale = Vector2(2, 2)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-shape = SubResource("RectangleShape2D_6tol3")
+shape = SubResource("RectangleShape2D_ptml5")
 
 [node name="HP" type="Sprite2D" parent="."]
 visible = false
@@ -46,7 +46,7 @@ offset_top = -18.0
 offset_right = 49.0
 offset_bottom = 5.0
 text = "40/40"
-label_settings = SubResource("LabelSettings_eb617")
+label_settings = SubResource("LabelSettings_fwvgu")
 horizontal_alignment = 1
 vertical_alignment = 1
 

--- a/Fight/invocation.tscn
+++ b/Fight/invocation.tscn
@@ -7,9 +7,9 @@
 [ext_resource type="Texture2D" uid="uid://di4dh5dwn3exu" path="res://Fight/Images/hp_display.png" id="5_eb3vf"]
 [ext_resource type="PackedScene" uid="uid://wjqjfqvfle7s" path="res://Fight/stats_perdu.tscn" id="6_aopma"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_ayh5f"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_e3a5c"]
 
-[sub_resource type="LabelSettings" id="LabelSettings_s7oo7"]
+[sub_resource type="LabelSettings" id="LabelSettings_yjpok"]
 font_size = 25
 
 [node name="Invocation" type="Node2D"]
@@ -30,7 +30,7 @@ position = Vector2(0, -10)
 scale = Vector2(2, 2)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-shape = SubResource("RectangleShape2D_ayh5f")
+shape = SubResource("RectangleShape2D_e3a5c")
 
 [node name="HP" type="Sprite2D" parent="."]
 visible = false
@@ -46,7 +46,7 @@ offset_top = -18.0
 offset_right = 49.0
 offset_bottom = 5.0
 text = "40/40"
-label_settings = SubResource("LabelSettings_s7oo7")
+label_settings = SubResource("LabelSettings_yjpok")
 horizontal_alignment = 1
 vertical_alignment = 1
 

--- a/Fight/invocation.tscn
+++ b/Fight/invocation.tscn
@@ -7,9 +7,9 @@
 [ext_resource type="Texture2D" uid="uid://di4dh5dwn3exu" path="res://Fight/Images/hp_display.png" id="5_eb3vf"]
 [ext_resource type="PackedScene" uid="uid://wjqjfqvfle7s" path="res://Fight/stats_perdu.tscn" id="6_aopma"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_glaiq"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_ayh5f"]
 
-[sub_resource type="LabelSettings" id="LabelSettings_kaxev"]
+[sub_resource type="LabelSettings" id="LabelSettings_s7oo7"]
 font_size = 25
 
 [node name="Invocation" type="Node2D"]
@@ -30,7 +30,7 @@ position = Vector2(0, -10)
 scale = Vector2(2, 2)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-shape = SubResource("RectangleShape2D_glaiq")
+shape = SubResource("RectangleShape2D_ayh5f")
 
 [node name="HP" type="Sprite2D" parent="."]
 visible = false
@@ -46,7 +46,7 @@ offset_top = -18.0
 offset_right = 49.0
 offset_bottom = 5.0
 text = "40/40"
-label_settings = SubResource("LabelSettings_kaxev")
+label_settings = SubResource("LabelSettings_s7oo7")
 horizontal_alignment = 1
 vertical_alignment = 1
 

--- a/Fight/invocation.tscn
+++ b/Fight/invocation.tscn
@@ -7,9 +7,9 @@
 [ext_resource type="Texture2D" uid="uid://di4dh5dwn3exu" path="res://Fight/Images/hp_display.png" id="5_eb3vf"]
 [ext_resource type="PackedScene" uid="uid://wjqjfqvfle7s" path="res://Fight/stats_perdu.tscn" id="6_aopma"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_e3a5c"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_6tol3"]
 
-[sub_resource type="LabelSettings" id="LabelSettings_yjpok"]
+[sub_resource type="LabelSettings" id="LabelSettings_eb617"]
 font_size = 25
 
 [node name="Invocation" type="Node2D"]
@@ -30,7 +30,7 @@ position = Vector2(0, -10)
 scale = Vector2(2, 2)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-shape = SubResource("RectangleShape2D_e3a5c")
+shape = SubResource("RectangleShape2D_6tol3")
 
 [node name="HP" type="Sprite2D" parent="."]
 visible = false
@@ -46,7 +46,7 @@ offset_top = -18.0
 offset_right = 49.0
 offset_bottom = 5.0
 text = "40/40"
-label_settings = SubResource("LabelSettings_yjpok")
+label_settings = SubResource("LabelSettings_eb617")
 horizontal_alignment = 1
 vertical_alignment = 1
 

--- a/Jeu/sort.gd
+++ b/Jeu/sort.gd
@@ -180,7 +180,8 @@ func parse_effets(lanceur, p_cible, p_effets, critique, centre, aoe):
 		else:
 			compte_cible[p_cible.id] = 1
 	for effet in p_effets.keys():
-		var new_effet = Effet.new(lanceur, p_cible, effet, p_effets[effet], critique, centre, aoe, self)
+		var combattant_effet = p_effets.duplicate(true)
+		var new_effet = Effet.new(lanceur, p_cible, effet, combattant_effet[effet], critique, centre, aoe, self)
 		if new_effet.instant:
 			new_effet.execute()
 		if new_effet.duree > 0:

--- a/Jeu/sort.gd
+++ b/Jeu/sort.gd
@@ -84,7 +84,7 @@ func execute_effets(lanceur, cases_cibles, centre) -> bool:
 			effets.has("DOMMAGE_FIXE"), 
 			critique, 
 			centre, 
-			aoe,
+			false,
 			self)
 		lanceur.combat.tilemap.glyphes_indexeur += 1
 		lanceur.combat.tilemap.glyphes.append(new_glyphe)
@@ -136,7 +136,10 @@ func execute_effets(lanceur, cases_cibles, centre) -> bool:
 			sort_valide = parse_effets(lanceur, combattant, effets, critique, centre, aoe) or sort_valide
 	if not trouve and cible == 2:
 		sort_valide = parse_effets(lanceur, cases_cibles, effets, critique, centre, true) or sort_valide
-	update_limite_lancers(lanceur)
+	if effets.has("MAUDIT_CASE"):
+		sort_valide = parse_effets(lanceur, cases_cibles, effets, critique, centre, true) or sort_valide
+	if sort_valide:
+		update_limite_lancers(lanceur)
 	
 	if not sort_valide:
 		print("Sort invalide, annulation de l'action !")
@@ -380,7 +383,7 @@ class Glyphe:
 				combattant.stats.pa -= delta_pa
 				combattant.stats.pm -= delta_pm
 				for effet in effets:
-					var new_effet = Effet.new(lanceur, combattant, effet, effets[effet], critique, centre, true, sort)
+					var new_effet = Effet.new(lanceur, combattant, effet, effets[effet], critique, centre, aoe, sort)
 					new_effet.instant = true
 					new_effet.execute()
 				triggered = true

--- a/Jeu/sorts.json
+++ b/Jeu/sorts.json
@@ -2872,7 +2872,7 @@
 			"cooldown_global": -1,
             "lancer_par_tour": -1,
             "lancer_par_cible": -1,
-            "desenvoute_delais": 0,
+            "desenvoute_delais": 1,
             "nombre_lancers": 1,
             "cumul_max": -1,
             "etat_requis": "",
@@ -3306,7 +3306,7 @@
 			"effets": {
 				"SACRIFICE": {
                     "base": {
-                        "duree": 1
+                        "duree": 3
                     }
                 }
 			}

--- a/Jeu/sorts.json
+++ b/Jeu/sorts.json
@@ -3479,7 +3479,7 @@
 			"cooldown": 0,
 			"cooldown_global": 0,
             "lancer_par_tour": -1,
-            "lancer_par_cible": -1,
+            "lancer_par_cible": 1,
             "desenvoute_delais": -1,
             "nombre_lancers": -1,
             "cumul_max": -1,
@@ -4472,27 +4472,32 @@
                 "CHANGE_STATS": {
                     "resistances_air": {
                         "base": {
-                            "valeur": 60
+                            "valeur": 60,
+                            "duree": 2
                         }
                     },
                     "resistances_terre": {
                         "base": {
-                            "valeur": 60
+                            "valeur": 60,
+                            "duree": 2
                         }
                     },
                     "resistances_feu": {
                         "base": {
-                            "valeur": 60
+                            "valeur": 60,
+                            "duree": 2
                         }
                     },
                     "resistances_eau": {
                         "base": {
-                            "valeur": 60
+                            "valeur": 60,
+                            "duree": 2
                         }
                     },
                     "resistance_zone": {
                         "base": {
-                            "valeur": -210
+                            "valeur": -210,
+                            "duree": 2
                         }
                     },
                 }

--- a/Jeu/sorts.json
+++ b/Jeu/sorts.json
@@ -1436,12 +1436,12 @@
             "etats_cible_interdits": [],
             "etats_lanceur_interdits": ["PORTE"],
 			"effets": {
-                "DEVIENT_INVISIBLE": {
+                "REVELE_INVISIBLE": {
                     "base": {
                         "duree": 2
                     }
                 },
-                "REVELE_INVISIBLE": {
+                "DEVIENT_INVISIBLE": {
                     "base": {
                         "duree": 2
                     }

--- a/Jeu/sorts.json
+++ b/Jeu/sorts.json
@@ -3317,7 +3317,7 @@
 			"po": [0, 0],
             "po_modifiable": 0,
 			"type_zone": 0,
-            "taille_zone": [0, 2],
+            "taille_zone": [1, 2],
 			"cible": 1,
 			"ldv": 1,
 			"type_ldv": 0,
@@ -3940,7 +3940,8 @@
                 },
                 "DOMMAGE_FIXE": {
                     "base": {
-                        "valeur": 80
+                        "valeur": 80,
+                        "maudit": 200
                     }
                 }
 			}
@@ -4555,42 +4556,50 @@
                         "CHANGE_STATS": {
                             "resistances_air": {
                                 "base": {
-                                    "valeur": -60
+                                    "valeur": -60,
+                                    "duree": 2
                                 }
                             },
                             "resistances_terre": {
                                 "base": {
-                                    "valeur": -60
+                                    "valeur": -60,
+                                    "duree": 2
                                 }
                             },
                             "resistances_feu": {
                                 "base": {
-                                    "valeur": -60
+                                    "valeur": -60,
+                                    "duree": 2
                                 }
                             },
                             "resistances_eau": {
                                 "base": {
-                                    "valeur": -60
+                                    "valeur": -60,
+                                    "duree": 2
                                 }
                             },
                             "dommages_air": {
                                 "base": {
-                                    "valeur": 60
+                                    "valeur": 60,
+                                    "duree": 2
                                 }
                             },
                             "dommages_terre": {
                                 "base": {
-                                    "valeur": 60
+                                    "valeur": 60,
+                                    "duree": 2
                                 }
                             },
                             "dommages_feu": {
                                 "base": {
-                                    "valeur": 60
+                                    "valeur": 60,
+                                    "duree": 2
                                 }
                             },
                             "dommages_eau": {
                                 "base": {
-                                    "valeur": 60
+                                    "valeur": 60,
+                                    "duree": 2
                                 }
                             }
                         }
@@ -4599,42 +4608,50 @@
                         "CHANGE_STATS": {
                             "resistances_air": {
                                 "base": {
-                                    "valeur": 60
+                                    "valeur": 60,
+                                    "duree": 2
                                 }
                             },
                             "resistances_terre": {
                                 "base": {
-                                    "valeur": 60
+                                    "valeur": 60,
+                                    "duree": 2
                                 }
                             },
                             "resistances_feu": {
                                 "base": {
-                                    "valeur": 60
+                                    "valeur": 60,
+                                    "duree": 2
                                 }
                             },
                             "resistances_eau": {
                                 "base": {
-                                    "valeur": 60
+                                    "valeur": 60,
+                                    "duree": 2
                                 }
                             },
                             "dommages_air": {
                                 "base": {
-                                    "valeur": -60
+                                    "valeur": -60,
+                                    "duree": 2
                                 }
                             },
                             "dommages_terre": {
                                 "base": {
-                                    "valeur": -60
+                                    "valeur": -60,
+                                    "duree": 2
                                 }
                             },
                             "dommages_feu": {
                                 "base": {
-                                    "valeur": -60
+                                    "valeur": -60,
+                                    "duree": 2
                                 }
                             },
                             "dommages_eau": {
                                 "base": {
-                                    "valeur": -60
+                                    "valeur": -60,
+                                    "duree": 2
                                 }
                             }
                         }


### PR DESCRIPTION
- Il n'est plus possible de soigner au dessus des PV max
- Un adversaire pétrifié ne compte plus dans le blocage
- La stabilisation empêche bien la poussée ou l'attirance
- Les délais de debuff sont appliqués correctement
- La Fleche Absorbande n'inverse plus les effets sur le tour de jeu suivant
- Démence peut bien être lancé lorsque le personnage a moins de 25% de vie
- Il n'est plus possible pour un personnage avec 20% de blocage de tacler un personnage ayant 120% d'esquive
- Transfert de vie ne soigne plus le lanceur
- Mauvais oeil est désormais lançable dans le vie / sur des cases inoccupées 
- Les feintes du Roublard durent 2 tours
- Les dommages de Piège Mortel ne sont plus réduits par les résistances de zone
- Les dommages de Piège Mortel sont augmentés par Mauvais oeil
- Piège Mortel n'est plus déclenché lors d'une attirance / poussée si le personnage déplacé ne fini pas sur le piège
- Evanescence dure désormais 2 tours
- Poison a maintenant une limite de 1 lancer par tour par cible
- Les sorts qui rendent invisibles le lanceur fonctionnent normalement