### PR TITLE
Another batch of bugfixes

### DIFF
--- a/Fight/Scripts/combattant.gd
+++ b/Fight/Scripts/combattant.gd
@@ -259,7 +259,7 @@ func joue_action(action: int, tile_pos: Vector2i):
 			stats.pa -= sort.pa
 			stats_perdu.ajoute(-sort.pa, "pa")
 			for effet in effets:
-				if effet.etat == "DOMMAGE_SI_UTILISE_PA":
+				if effet.etat == "DOMMAGE_SI_UTILISE_PA" and (effet.sort.nom != sort.nom or effet.lanceur.id != id):
 					for i in range(sort.pa):
 						effet.execute()
 			if not is_invocation:

--- a/Fight/Scripts/combattant.gd
+++ b/Fight/Scripts/combattant.gd
@@ -425,9 +425,11 @@ func fin_tour():
 
 
 func meurt():
+	var is_porteur = false
 	if check_etats(["PORTE_ALLIE", "PORTE_ENNEMI"]):
 		var effet_lance = Effet.new(self, grid_pos, "LANCE", 1, false, grid_pos, false, null)
 		effet_lance.execute()
+		is_porteur = true
 	
 	for combattant in combat.combattants:
 		var new_effets = []
@@ -440,9 +442,10 @@ func meurt():
 					combattant.max_stats.hp -= effet.boost_hp
 		combattant.effets = new_effets
 	
-	var map_pos = combat.tilemap.local_to_map(position)
-	combat.tilemap.a_star_grid.set_point_solid(grid_pos, false)
-	combat.tilemap.grid[grid_pos[0]][grid_pos[1]] = combat.tilemap.get_cell_atlas_coords(1, map_pos).x
+	if not is_porteur:
+		var map_pos = combat.tilemap.local_to_map(position)
+		combat.tilemap.a_star_grid.set_point_solid(grid_pos, false)
+		combat.tilemap.grid[grid_pos[0]][grid_pos[1]] = combat.tilemap.get_cell_atlas_coords(1, map_pos).x
 	is_mort = true
 	print(classe, "_", str(id), " est mort.")
 	queue_free()

--- a/Fight/Scripts/combattant.gd
+++ b/Fight/Scripts/combattant.gd
@@ -272,6 +272,7 @@ func joue_action(action: int, tile_pos: Vector2i):
 		combat.change_action(7)
 	combat.stats_select.update(stats)
 	combat.check_morts()
+	combat.tilemap.affiche_astar_obstacles()
 
 
 func affiche_stats_change(valeur, stat):
@@ -296,6 +297,8 @@ func check_tacle_unit(case: Vector2i) -> bool:
 
 
 func deplace_perso(chemin: Array):
+	if stats.pm <= 0:
+		return
 	var tacled = check_tacle_unit(grid_pos)
 	var pm_utilise = 0
 	for effet in effets:
@@ -412,6 +415,7 @@ func debut_tour():
 	if check_etats(["IMMOBILISE"]):
 		stats.pm = 0
 	combat.check_morts()
+	combat.tilemap.affiche_astar_obstacles()
 
 
 func fin_tour():
@@ -446,6 +450,9 @@ func meurt():
 		var map_pos = combat.tilemap.local_to_map(position)
 		combat.tilemap.a_star_grid.set_point_solid(grid_pos, false)
 		combat.tilemap.grid[grid_pos[0]][grid_pos[1]] = combat.tilemap.get_cell_atlas_coords(1, map_pos).x
+	else:
+		combat.tilemap.a_star_grid.set_point_solid(grid_pos, true)
+		combat.tilemap.grid[grid_pos[0]][grid_pos[1]] = -2
 	is_mort = true
 	print(classe, "_", str(id), " est mort.")
 	queue_free()
@@ -460,7 +467,7 @@ func execute_effets():
 
 
 func check_etats(etats: Array) -> bool:
-	if "VIE_FAIBLE" in etats and stats.hp < int(max_stats.hp / 4):
+	if "VIE_FAIBLE" in etats and stats.hp < int(max_stats.hp / 4.0):
 		return true
 	for effet in effets:
 		if effet.etat in etats:

--- a/Fight/Scripts/combattant.gd
+++ b/Fight/Scripts/combattant.gd
@@ -28,6 +28,7 @@ var zone: Array
 
 var is_selected: bool
 var is_hovered: bool
+var is_mort: bool
 
 var cercle_bleu = preload("res://Fight/Images/cercle_personnage_bleu.png")
 var cercle_rouge = preload("res://Fight/Images/cercle_personnage_rouge.png")
@@ -179,7 +180,7 @@ func check_case_bonus():
 	match case_id:
 		2:
 			categorie = "CHANGE_STATS"
-			var valeur = 30 * -(int(maudit) * 2 - 1) * (int(combat.tour >= 15) + 1)
+			var valeur = 30 * -(int(maudit) * 2 - 1) * (int(combat.tour >= 15 and GlobalData.mort_subite_active) + 1)
 			contenu = {
 				"dommages_air":{"base":{"valeur":valeur,"duree":1}},
 				"dommages_terre":{"base":{"valeur":valeur,"duree":1}},
@@ -188,7 +189,7 @@ func check_case_bonus():
 			}
 		3:
 			categorie = "CHANGE_STATS"
-			var valeur = 30 * -(int(maudit) * 2 - 1) * (int(combat.tour >= 15) + 1)
+			var valeur = 30 * -(int(maudit) * 2 - 1) * (int(combat.tour >= 15 and GlobalData.mort_subite_active) + 1)
 			contenu = {
 				"resistances_air":{"base":{"valeur":valeur,"duree":1}},
 				"resistances_terre":{"base":{"valeur":valeur,"duree":1}},
@@ -197,29 +198,35 @@ func check_case_bonus():
 			}
 		4:
 			categorie = "SOIN" if not maudit else "DOMMAGE_FIXE"
-			var valeur =  7 * (int(combat.tour >= 15) + 1)
+			var valeur =  7 * (int(combat.tour >= 15 and GlobalData.mort_subite_active) + 1)
 			contenu = {"base":{"valeur":valeur}}
 		5:
 			categorie = "CHANGE_STATS"
-			var valeur = 2 * -(int(maudit) * 2 - 1) * (int(combat.tour >= 15) + 1)
+			var valeur = 2 * -(int(maudit) * 2 - 1) * (int(combat.tour >= 15 and GlobalData.mort_subite_active) + 1)
 			contenu = {"pa":{"base":{"valeur":valeur,"duree":1}}}
 		6:
 			categorie = "CHANGE_STATS"
-			var valeur = 2 * -(int(maudit) * 2 - 1) * (int(combat.tour >= 15) + 1)
+			var valeur = 2 * -(int(maudit) * 2 - 1) * (int(combat.tour >= 15 and GlobalData.mort_subite_active) + 1)
 			contenu = {"po":{"base":{"valeur":valeur,"duree":1}}}
 		7:
 			categorie = "CHANGE_STATS"
-			var valeur = 25 * -(int(maudit) * 2 - 1) * (int(combat.tour >= 15) + 1)
+			var valeur = 25 * -(int(maudit) * 2 - 1) * (int(combat.tour >= 15 and GlobalData.mort_subite_active) + 1)
 			contenu = {"soins":{"base":{"valeur":valeur,"duree":1}}}
 		8:
 			categorie = "DOMMAGE_POURCENT"
-			contenu = {"base":{"valeur":80.0 if combat.tour < 15 and not maudit else (99.84 if combat.tour >= 15 and maudit else 96.0)}}
+			contenu = {"base":{"valeur":80.0 if combat.tour < 15 and not maudit else (99.84 if combat.tour >= 15 and GlobalData.mort_subite_active and maudit else 96.0)}}
 		9:
 			categorie = "DOMMAGE_FIXE"
-			var valeur = 15 * (int(maudit) + 1) * (int(combat.tour >= 15) + 1)
+			var valeur = 15 * (int(maudit) + 1) * (int(combat.tour >= 15 and GlobalData.mort_subite_active) + 1)
 			contenu = {"base":{"valeur":valeur}}
 	var effet = Effet.new(self, self, categorie, contenu, false, grid_pos, false, null)
+	effet.debuffable = false
+	var temp_soins = stats.soins
+	stats.soins = 0
 	effet.execute()
+	stats.soins = temp_soins
+	if effet.duree > 0:
+		effets.append(effet)
 
 
 func desactive_cadran():
@@ -232,32 +239,6 @@ func active_cadran():
 	for combattant in combat.combattants:
 		if combattant.is_invocation and combattant.invocateur.id == id:
 			combat.tilemap.grid[combattant.grid_pos[0]][combattant.grid_pos[1]] = -2
-
-
-func debut_tour():
-	retrait_durees()
-	execute_effets()
-	check_case_bonus()
-	desactive_cadran()
-	var delta_hp = max_stats.hp - stats.hp
-	stats = init_stats.copy().add(stat_ret).add(stat_buffs)
-	stats.hp -= delta_hp
-	all_path = combat.tilemap.get_atteignables(grid_pos, stats.pm)
-	if check_etats(["PETRIFIE"]):
-		combat.passe_tour()
-	if not check_etats(["INVISIBLE"]):
-		combat.tilemap.grid[grid_pos[0]][grid_pos[1]] = -2
-	combat.check_morts()
-
-
-func fin_tour():
-	active_cadran()
-	retrait_cooldown()
-	stat_ret = Stats.new()
-	var temp_hp = stats.hp
-	stats = init_stats.copy().add(stat_buffs)
-	stats.hp = temp_hp
-	combat.check_morts()
 
 
 func joue_action(action: int, tile_pos: Vector2i):
@@ -298,6 +279,8 @@ func affiche_stats_change(valeur, stat):
 
 
 func check_tacle_unit(case: Vector2i) -> bool:
+	if check_etats(["PORTE"]):
+		return false
 	var voisins = [Vector2i(-1, 0), Vector2i(1, 0), Vector2i(0, -1), Vector2i(0, 1)]
 	var blocage_total = 0
 	for combattant in combat.combattants:
@@ -413,6 +396,34 @@ func oriente_vers(pos: Vector2i):
 	change_orientation(min_vec)
 
 
+func debut_tour():
+	retrait_durees()
+	execute_effets()
+	check_case_bonus()
+	desactive_cadran()
+	var delta_hp = max_stats.hp - stats.hp
+	stats = init_stats.copy().add(stat_ret).add(stat_buffs)
+	stats.hp -= delta_hp
+	all_path = combat.tilemap.get_atteignables(grid_pos, stats.pm)
+	if check_etats(["PETRIFIE"]):
+		combat.passe_tour()
+	if not check_etats(["INVISIBLE"]):
+		combat.tilemap.grid[grid_pos[0]][grid_pos[1]] = -2
+	if check_etats(["IMMOBILISE"]):
+		stats.pm = 0
+	combat.check_morts()
+
+
+func fin_tour():
+	active_cadran()
+	retrait_cooldown()
+	stat_ret = Stats.new()
+	var temp_hp = stats.hp
+	stats = init_stats.copy().add(stat_buffs)
+	stats.hp = temp_hp
+	combat.check_morts()
+
+
 func meurt():
 	if check_etats(["PORTE_ALLIE", "PORTE_ENNEMI"]):
 		var effet_lance = Effet.new(self, grid_pos, "LANCE", 1, false, grid_pos, false, null)
@@ -432,6 +443,7 @@ func meurt():
 	var map_pos = combat.tilemap.local_to_map(position)
 	combat.tilemap.a_star_grid.set_point_solid(grid_pos, false)
 	combat.tilemap.grid[grid_pos[0]][grid_pos[1]] = combat.tilemap.get_cell_atlas_coords(1, map_pos).x
+	is_mort = true
 	print(classe, "_", str(id), " est mort.")
 	queue_free()
 
@@ -472,6 +484,13 @@ func retrait_durees():
 			if effet.duree > 0:
 				new_effets.append(effet)
 		combattant.effets = new_effets
+		combattant.stat_buffs = Stats.new()
+		combattant.max_stats = combattant.init_stats.copy()
+		combattant.execute_effets()
+		var delta_hp = combattant.max_stats.hp - combattant.stats.hp
+		combattant.stats = combattant.init_stats.copy().add(combattant.stat_ret).add(combattant.stat_buffs)
+		combattant.stats.hp -= delta_hp
+		
 	
 	var new_map_glyphes = []
 	for glyphe in combat.tilemap.glyphes:

--- a/Fight/Scripts/combattant.gd
+++ b/Fight/Scripts/combattant.gd
@@ -272,7 +272,6 @@ func joue_action(action: int, tile_pos: Vector2i):
 		combat.change_action(7)
 	combat.stats_select.update(stats)
 	combat.check_morts()
-	combat.tilemap.affiche_astar_obstacles()
 
 
 func affiche_stats_change(valeur, stat):
@@ -415,7 +414,6 @@ func debut_tour():
 	if check_etats(["IMMOBILISE"]):
 		stats.pm = 0
 	combat.check_morts()
-	combat.tilemap.affiche_astar_obstacles()
 
 
 func fin_tour():

--- a/Fight/Scripts/effet.gd
+++ b/Fight/Scripts/effet.gd
@@ -877,8 +877,10 @@ func porte():
 		var etat_lanceur = "PORTE_ALLIE" if lanceur.equipe == cible.equipe else "PORTE_ENNEMI"
 		var effet_lanceur = Effet.new(lanceur, cible, etat_lanceur, contenu, false, lanceur.grid_pos, false, sort)
 		effet_lanceur.etat = etat_lanceur
+		effet_lanceur.debuffable = false
 		lanceur.effets.append(effet_lanceur)
 		etat = "PORTE"
+		debuffable = false
 		var map_pos = cible.grid_pos - combat.offset
 		cible.combat.tilemap.a_star_grid.set_point_solid(cible.grid_pos, false)
 		cible.combat.tilemap.grid[cible.grid_pos[0]][cible.grid_pos[1]] = cible.combat.tilemap.get_cell_atlas_coords(1, map_pos).x
@@ -897,13 +899,16 @@ func lance():
 				combat.tilemap.a_star_grid.set_point_solid(combattant.grid_pos)
 				combat.tilemap.grid[combattant.grid_pos[0]][combattant.grid_pos[1]] = -2
 				combattant.z_index = 0
-				var new_sort = sort.copy()
-				new_sort.pa = 0
-				new_sort.cible = GlobalData.Cible.LIBRE
-				new_sort.effets.erase("LANCE")
+				var new_sort = null
+				if sort != null:
+					new_sort = sort.copy()
+					new_sort.pa = 0
+					new_sort.cible = GlobalData.Cible.LIBRE
+					new_sort.effets.erase("LANCE")
 				combattant.retire_etats(["PORTE"])
 				lanceur.retire_etats(["PORTE_ALLIE", "PORTE_ENNEMI"])
-				new_sort.execute_effets(lanceur, [centre], centre)
+				if new_sort != null:
+					new_sort.execute_effets(lanceur, [centre], centre)
 				combat.tilemap.update_glyphes()
 				return
 

--- a/Fight/Scripts/effet.gd
+++ b/Fight/Scripts/effet.gd
@@ -611,6 +611,7 @@ func change_stats():
 				lanceur.max_stats[stat] += contenu[stat][base_crit]["retour"]
 			if stat in ["pa", "pm", "hp"]:
 				lanceur.stats_perdu.ajoute(contenu[stat][base_crit]["retour"], stat)
+	instant = false
 
 
 func reverse_change_stats():
@@ -773,7 +774,9 @@ func avance():
 
 func immobilise():
 	etat = "IMMOBILISE"
-	print(cible.classe, "_", str(cible.id), " est immobilisé (", duree, " tours).")
+	if instant:
+		print(cible.classe, "_", str(cible.id), " est immobilisé (", duree, " tours).")
+	instant = false
 
 
 func teleporte():
@@ -788,7 +791,9 @@ func transpose():
 
 func petrifie():
 	etat = "PETRIFIE"
-	print(cible.classe, "_", str(cible.id), " est pétrifié (", duree, " tours).")
+	if instant:
+		print(cible.classe, "_", str(cible.id), " est pétrifié (", duree, " tours).")
+	instant = false
 
 
 func rate_sort():
@@ -832,27 +837,37 @@ func desenvoute():
 
 func non_portable():
 	etat = "NON_PORTABLE"
-	print(cible.classe, "_", str(cible.id), " est non-portable (", duree, " tours).")
+	if instant:
+		print(cible.classe, "_", str(cible.id), " est non-portable (", duree, " tours).")
+	instant = false
 
 
 func intransposable():
 	etat = "INTRANSPOSABLE"
-	print(cible.classe, "_", str(cible.id), " est intransposable (", duree, " tours).")
+	if instant:
+		print(cible.classe, "_", str(cible.id), " est intransposable (", duree, " tours).")
+	instant = false
 
 
 func immunise():
 	etat = "IMMUNISE"
-	print(cible.classe, "_", str(cible.id), " est immunisé (", duree, " tours).")
+	if instant:
+		print(cible.classe, "_", str(cible.id), " est immunisé (", duree, " tours).")
+	instant = false
 
 
 func stabilise():
 	etat = "STABILISE"
-	print(cible.classe, "_", str(cible.id), " est stabilisé (", duree, " tours).")
+	if instant:
+		print(cible.classe, "_", str(cible.id), " est stabilisé (", duree, " tours).")
+	instant = false
 
 
 func renvoie_sort():
 	etat = "RENVOIE_SORT"
-	print(cible.classe, "_", str(cible.id), " renvoie les sorts (", duree, " tours).")
+	if instant:
+		print(cible.classe, "_", str(cible.id), " renvoie les sorts (", duree, " tours).")
+	instant = false
 
 
 func invocation():
@@ -922,7 +937,9 @@ func lance():
 
 func picole():
 	etat = "PICOLE"
-	print(lanceur.classe, "_", str(lanceur.id), " entre dans l'état picole.")
+	if instant:
+		print(lanceur.classe, "_", str(lanceur.id), " entre dans l'état picole.")
+	instant = false
 
 
 func sacrifice():
@@ -931,7 +948,9 @@ func sacrifice():
 			cible.retire_etats(["SACRIFICE"])
 			break
 	etat = "SACRIFICE"
-	print(lanceur.classe, "_", str(lanceur.id), " sacrifie ", cible.classe, "_", str(cible.id), " (", duree, " tours).")
+	if instant:
+		print(lanceur.classe, "_", str(lanceur.id), " sacrifie ", cible.classe, "_", str(cible.id), " (", duree, " tours).")
+	instant = false
 
 
 func tourne():
@@ -940,12 +959,16 @@ func tourne():
 
 func immunise_retrait_pa():
 	etat = "IMMUNISE_RETRAIT_PA"
-	print(cible.classe, "_", str(cible.id), " est immunisé au retrait PA (", duree, " tours).")
+	if instant:
+		print(cible.classe, "_", str(cible.id), " est immunisé au retrait PA (", duree, " tours).")
+	instant = false
 
 
 func immunise_retrait_pm():
 	etat = "IMMUNISE_RETRAIT_PM"
-	print(cible.classe, "_", str(cible.id), " est immunisé au retrait PM (", duree, " tours).")
+	if instant:
+		print(cible.classe, "_", str(cible.id), " est immunisé au retrait PM (", duree, " tours).")
+	instant = false
 
 
 func suicide():

--- a/Fight/Scripts/effet.gd
+++ b/Fight/Scripts/effet.gd
@@ -921,15 +921,14 @@ func lance():
 				combat.tilemap.a_star_grid.set_point_solid(combattant.grid_pos)
 				combat.tilemap.grid[combattant.grid_pos[0]][combattant.grid_pos[1]] = -2
 				combattant.z_index = 0
+				combattant.retire_etats(["PORTE"])
+				lanceur.retire_etats(["PORTE_ALLIE", "PORTE_ENNEMI"])
 				var new_sort = null
 				if sort != null:
 					new_sort = sort.copy()
 					new_sort.pa = 0
 					new_sort.cible = GlobalData.Cible.LIBRE
 					new_sort.effets.erase("LANCE")
-				combattant.retire_etats(["PORTE"])
-				lanceur.retire_etats(["PORTE_ALLIE", "PORTE_ENNEMI"])
-				if new_sort != null:
 					new_sort.execute_effets(lanceur, [centre], centre)
 				combat.tilemap.update_glyphes()
 				return

--- a/Fight/Scripts/effet.gd
+++ b/Fight/Scripts/effet.gd
@@ -280,9 +280,16 @@ func update_sacrifice(p_cible, type):
 	return p_cible
 
 
-func applique_dommage(base, stat, resistance, orientation_bonus, type):
+func applique_dommage(base, stat_element: String, resistance_element: String, orientation_bonus, type):
 	if cible.check_etats(["SACRIFICE"]) and not type in ["soin", "retour", "pourcent_retour"]:
 		cible = update_sacrifice(cible, type)
+	
+	var stat = 0.0
+	if not stat_element.is_empty():
+		stat = lanceur.stats[stat_element]
+	var resistance = 0.0
+	if not resistance_element.is_empty():
+		resistance = cible.stats[resistance_element]
 	
 	if type in ["pourcent", "pourcent_retour"]:
 		base = cible.stats.hp * (base / 100.0)
@@ -333,15 +340,15 @@ func dommage_fixe():
 		return
 	var base_crit = trouve_crit()
 	if contenu[base_crit].has("allies") and lanceur.equipe == cible.equipe:
-		applique_dommage(contenu[base_crit]["allies"], 0.0, 0.0, false, "normal")
+		applique_dommage(contenu[base_crit]["allies"], "", "", false, "normal")
 	elif contenu[base_crit].has("invocations") and cible.is_invocation: 
-		applique_dommage(contenu[base_crit]["invocations"], 0.0, 0.0, false, "normal")
+		applique_dommage(contenu[base_crit]["invocations"], "", "", false, "normal")
 	elif contenu[base_crit].has("maudit") and centre in combat.tilemap.cases_maudites.values():
-		applique_dommage(contenu[base_crit]["maudit"], 0.0, 0.0, false, "normal")
+		applique_dommage(contenu[base_crit]["maudit"], "", "", false, "normal")
 	elif contenu[base_crit].has("valeur"):
-		applique_dommage(contenu[base_crit]["valeur"], 0.0, 0.0, false, "normal")
+		applique_dommage(contenu[base_crit]["valeur"], "", "", false, "normal")
 	if contenu[base_crit].has("retour"):
-		applique_dommage(contenu[base_crit]["retour"], 0.0, 0.0, false, "retour")
+		applique_dommage(contenu[base_crit]["retour"], "", "", false, "retour")
 
 
 func dommage_pourcent():
@@ -349,13 +356,13 @@ func dommage_pourcent():
 		return
 	var base_crit = trouve_crit()
 	if contenu[base_crit].has("allies") and lanceur.equipe == cible.equipe:
-		applique_dommage(contenu[base_crit]["allies"], 0.0, 0.0, false, "pourcent")
+		applique_dommage(contenu[base_crit]["allies"], "", "", false, "pourcent")
 	elif contenu[base_crit].has("invocations") and cible.is_invocation:
-		applique_dommage(contenu[base_crit]["invocations"], 0.0, 0.0, false, "pourcent") 
+		applique_dommage(contenu[base_crit]["invocations"], "", "", false, "pourcent") 
 	elif contenu[base_crit].has("valeur"):
-		applique_dommage(contenu[base_crit]["valeur"], 0.0, 0.0, false, "pourcent") 
+		applique_dommage(contenu[base_crit]["valeur"], "", "", false, "pourcent") 
 	if contenu[base_crit].has("retour"):
-		applique_dommage(contenu[base_crit]["retour"], 0.0, 0.0, false, "pourcent_retour") 
+		applique_dommage(contenu[base_crit]["retour"], "", "", false, "pourcent_retour") 
 	if cible.stats.hp <= 0:
 		cible.stats.hp = 1
 
@@ -418,13 +425,13 @@ func dommage_air():
 		return
 	var base_crit = trouve_crit()
 	if contenu[base_crit].has("allies") and lanceur.equipe == cible.equipe:
-		applique_dommage(contenu[base_crit]["allies"], lanceur.stats.dommages_air, cible.stats.resistances_air, not aoe, "normal") 
+		applique_dommage(contenu[base_crit]["allies"], "dommages_air", "resistances_air", not aoe, "normal") 
 	elif contenu[base_crit].has("invocations") and cible.is_invocation: 
-		applique_dommage(contenu[base_crit]["invocations"], lanceur.stats.dommages_air, cible.stats.resistances_air, not aoe, "normal") 
+		applique_dommage(contenu[base_crit]["invocations"], "dommages_air", "resistances_air", not aoe, "normal") 
 	elif contenu[base_crit].has("valeur"):
-		applique_dommage(contenu[base_crit]["valeur"], lanceur.stats.dommages_air, cible.stats.resistances_air, not aoe, "normal") 
+		applique_dommage(contenu[base_crit]["valeur"], "dommages_air", "resistances_air", not aoe, "normal") 
 	if contenu[base_crit].has("retour"):
-		applique_dommage(contenu[base_crit]["retour"], lanceur.stats.dommages_air, lanceur.stats.resistances_air, false, "retour") 
+		applique_dommage(contenu[base_crit]["retour"], "dommages_air", "resistances_air", false, "retour") 
 
 
 func dommage_terre():
@@ -432,13 +439,13 @@ func dommage_terre():
 		return
 	var base_crit = trouve_crit()
 	if contenu[base_crit].has("allies") and lanceur.equipe == cible.equipe:
-		applique_dommage(contenu[base_crit]["allies"], lanceur.stats.dommages_terre, cible.stats.resistances_terre, not aoe, "normal") 
+		applique_dommage(contenu[base_crit]["allies"], "dommages_terre", "resistances_terre", not aoe, "normal") 
 	elif contenu[base_crit].has("invocations") and cible.is_invocation: 
-		applique_dommage(contenu[base_crit]["invocations"], lanceur.stats.dommages_terre, cible.stats.resistances_terre, not aoe, "normal") 
+		applique_dommage(contenu[base_crit]["invocations"], "dommages_terre", "resistances_terre", not aoe, "normal") 
 	elif contenu[base_crit].has("valeur"):
-		applique_dommage(contenu[base_crit]["valeur"], lanceur.stats.dommages_terre, cible.stats.resistances_terre, not aoe, "normal") 
+		applique_dommage(contenu[base_crit]["valeur"], "dommages_terre", "resistances_terre", not aoe, "normal") 
 	if contenu[base_crit].has("retour"):
-		applique_dommage(contenu[base_crit]["retour"], lanceur.stats.dommages_terre, lanceur.stats.resistances_terre, false, "retour") 
+		applique_dommage(contenu[base_crit]["retour"], "dommages_terre", "resistances_terre", false, "retour") 
 
 
 func dommage_feu():
@@ -446,13 +453,13 @@ func dommage_feu():
 		return
 	var base_crit = trouve_crit()
 	if contenu[base_crit].has("allies") and lanceur.equipe == cible.equipe:
-		applique_dommage(contenu[base_crit]["allies"], lanceur.stats.dommages_feu, cible.stats.resistances_feu, not aoe, "normal") 
+		applique_dommage(contenu[base_crit]["allies"], "dommages_feu", "resistances_feu", not aoe, "normal") 
 	elif contenu[base_crit].has("invocations") and cible.is_invocation:  
-		applique_dommage(contenu[base_crit]["invocations"], lanceur.stats.dommages_feu, cible.stats.resistances_feu, not aoe, "normal") 
+		applique_dommage(contenu[base_crit]["invocations"], "dommages_feu", "resistances_feu", not aoe, "normal") 
 	elif contenu[base_crit].has("valeur"):
-		applique_dommage(contenu[base_crit]["valeur"], lanceur.stats.dommages_feu, cible.stats.resistances_feu, not aoe, "normal") 
+		applique_dommage(contenu[base_crit]["valeur"], "dommages_feu", "resistances_feu", not aoe, "normal") 
 	if contenu[base_crit].has("retour"):
-		applique_dommage(contenu[base_crit]["retour"], lanceur.stats.dommages_feu, lanceur.stats.resistances_feu, false, "retour") 
+		applique_dommage(contenu[base_crit]["retour"], "dommages_feu", "resistances_feu", false, "retour") 
 
 
 func dommage_eau():
@@ -460,13 +467,13 @@ func dommage_eau():
 		return
 	var base_crit = trouve_crit()
 	if contenu[base_crit].has("allies") and lanceur.equipe == cible.equipe:
-		applique_dommage(contenu[base_crit]["allies"], lanceur.stats.dommages_eau, cible.stats.resistances_eau, not aoe, "normal") 
+		applique_dommage(contenu[base_crit]["allies"], "dommages_eau", "resistances_eau", not aoe, "normal") 
 	elif contenu[base_crit].has("invocations") and cible.is_invocation:  
-		applique_dommage(contenu[base_crit]["invocations"], lanceur.stats.dommages_eau, cible.stats.resistances_eau, not aoe, "normal") 
+		applique_dommage(contenu[base_crit]["invocations"], "dommages_eau", "resistances_eau", not aoe, "normal") 
 	elif contenu[base_crit].has("valeur"):
-		applique_dommage(contenu[base_crit]["valeur"], lanceur.stats.dommages_eau, cible.stats.resistances_eau, not aoe, "normal") 
+		applique_dommage(contenu[base_crit]["valeur"], "dommages_eau", "resistances_eau", not aoe, "normal") 
 	if contenu[base_crit].has("retour"):
-		applique_dommage(contenu[base_crit]["retour"], lanceur.stats.dommages_eau, lanceur.stats.resistances_eau, false, "retour") 
+		applique_dommage(contenu[base_crit]["retour"], "dommages_eau", "resistances_eau", false, "retour") 
 
 
 func vole_air():
@@ -474,11 +481,11 @@ func vole_air():
 		return
 	var base_crit = trouve_crit()
 	if contenu[base_crit].has("allies") and lanceur.equipe == cible.equipe:
-		applique_dommage(contenu[base_crit]["allies"], lanceur.stats.dommages_air, cible.stats.resistances_air, not aoe, "vol") 
+		applique_dommage(contenu[base_crit]["allies"], "dommages_air", "resistances_air", not aoe, "vol") 
 	elif contenu[base_crit].has("invocations") and cible.is_invocation: 
-		applique_dommage(contenu[base_crit]["invocations"], lanceur.stats.dommages_air, cible.stats.resistances_air, not aoe, "vol") 
+		applique_dommage(contenu[base_crit]["invocations"], "dommages_air", "resistances_air", not aoe, "vol") 
 	elif contenu[base_crit].has("valeur"):
-		applique_dommage(contenu[base_crit]["valeur"], lanceur.stats.dommages_air, cible.stats.resistances_air, not aoe, "vol") 
+		applique_dommage(contenu[base_crit]["valeur"], "dommages_air", "resistances_air", not aoe, "vol") 
 	if lanceur.stats.hp > lanceur.max_stats.hp:
 		lanceur.stats.hp = lanceur.max_stats.hp
 
@@ -488,11 +495,11 @@ func vole_terre():
 		return
 	var base_crit = trouve_crit()
 	if contenu[base_crit].has("allies") and lanceur.equipe == cible.equipe:
-		applique_dommage(contenu[base_crit]["allies"], lanceur.stats.dommages_terre, cible.stats.resistances_terre, not aoe, "vol") 
+		applique_dommage(contenu[base_crit]["allies"], "dommages_terre", "resistances_terre", not aoe, "vol") 
 	elif contenu[base_crit].has("invocations") and cible.is_invocation: 
-		applique_dommage(contenu[base_crit]["invocations"], lanceur.stats.dommages_terre, cible.stats.resistances_terre, not aoe, "vol") 
+		applique_dommage(contenu[base_crit]["invocations"], "dommages_terre", "resistances_terre", not aoe, "vol") 
 	elif contenu[base_crit].has("valeur"):
-		applique_dommage(contenu[base_crit]["valeur"], lanceur.stats.dommages_terre, cible.stats.resistances_terre, not aoe, "vol") 
+		applique_dommage(contenu[base_crit]["valeur"], "dommages_terre", "resistances_terre", not aoe, "vol") 
 	if lanceur.stats.hp > lanceur.max_stats.hp:
 		lanceur.stats.hp = lanceur.max_stats.hp
 
@@ -502,11 +509,11 @@ func vole_feu():
 		return
 	var base_crit = trouve_crit()
 	if contenu[base_crit].has("allies") and lanceur.equipe == cible.equipe:
-		applique_dommage(contenu[base_crit]["allies"], lanceur.stats.dommages_feu, cible.stats.resistances_feu, not aoe, "vol") 
+		applique_dommage(contenu[base_crit]["allies"], "dommages_feu", "resistances_feu", not aoe, "vol") 
 	elif contenu[base_crit].has("invocations") and cible.is_invocation: 
-		applique_dommage(contenu[base_crit]["invocations"], lanceur.stats.dommages_feu, cible.stats.resistances_feu, not aoe, "vol") 
+		applique_dommage(contenu[base_crit]["invocations"], "dommages_feu", "resistances_feu", not aoe, "vol") 
 	elif contenu[base_crit].has("valeur"):
-		applique_dommage(contenu[base_crit]["valeur"], lanceur.stats.dommages_feu, cible.stats.resistances_feu, not aoe, "vol") 
+		applique_dommage(contenu[base_crit]["valeur"], "dommages_feu", "resistances_feu", not aoe, "vol") 
 	if lanceur.stats.hp > lanceur.max_stats.hp:
 		lanceur.stats.hp = lanceur.max_stats.hp
 
@@ -516,11 +523,11 @@ func vole_eau():
 		return
 	var base_crit = trouve_crit()
 	if contenu[base_crit].has("allies") and lanceur.equipe == cible.equipe:
-		applique_dommage(contenu[base_crit]["allies"], lanceur.stats.dommages_eau, cible.stats.resistances_eau, not aoe, "vol") 
+		applique_dommage(contenu[base_crit]["allies"], "dommages_eau", "resistances_eau", not aoe, "vol") 
 	elif contenu[base_crit].has("invocations") and cible.is_invocation: 
-		applique_dommage(contenu[base_crit]["invocations"], lanceur.stats.dommages_eau, cible.stats.resistances_eau, not aoe, "vol") 
+		applique_dommage(contenu[base_crit]["invocations"], "dommages_eau", "resistances_eau", not aoe, "vol") 
 	elif contenu[base_crit].has("valeur"):
-		applique_dommage(contenu[base_crit]["valeur"], lanceur.stats.dommages_eau, cible.stats.resistances_eau, not aoe, "vol") 
+		applique_dommage(contenu[base_crit]["valeur"], "dommages_eau", "resistances_eau", not aoe, "vol") 
 	if lanceur.stats.hp > lanceur.max_stats.hp:
 		lanceur.stats.hp = lanceur.max_stats.hp
 
@@ -530,11 +537,11 @@ func soin():
 		return
 	var base_crit = trouve_crit()
 	if contenu[base_crit].has("allies") and lanceur.equipe == cible.equipe:
-		applique_dommage(contenu[base_crit]["allies"], lanceur.stats.soins, 0, false, "soin") 
+		applique_dommage(contenu[base_crit]["allies"], "soins", "", false, "soin") 
 	elif contenu[base_crit].has("invocations") and cible.is_invocation: 
-		applique_dommage(contenu[base_crit]["invocations"], lanceur.stats.soins, 0, false, "soin") 
+		applique_dommage(contenu[base_crit]["invocations"], "soins", "", false, "soin") 
 	elif contenu[base_crit].has("valeur"):
-		applique_dommage(contenu[base_crit]["valeur"], lanceur.stats.soins, 0, false, "soin") 
+		applique_dommage(contenu[base_crit]["valeur"], "soins", "", false, "soin") 
 	if lanceur.stats.hp > lanceur.max_stats.hp:
 		lanceur.stats.hp = lanceur.max_stats.hp
 

--- a/Fight/Scripts/invocation.gd
+++ b/Fight/Scripts/invocation.gd
@@ -173,7 +173,7 @@ func chemin_vers_proche() -> Array:
 					min_dist = len(chemin)
 					min_chemin = chemin
 					min_hp = combattant.stats.hp
-				elif len(chemin) == min_dist and len(chemin) > 0:
+				elif len(chemin) == min_dist and len(chemin) > 0 and combattant.stats.hp < min_hp:
 					min_dist = len(chemin)
 					min_chemin = chemin
 					min_hp = combattant.stats.hp
@@ -205,7 +205,7 @@ func joue_ia():
 	combat.check_morts()
 	if is_mort:
 		return
-	if stats.pm > 0:
+	if stats.pm > 0 and init_stats.pm > 0:
 		var chemin = chemin_vers_proche()
 		if len(chemin) > stats.pm + 1:
 			chemin = chemin.slice(0, stats.pm + 1)

--- a/Fight/Scripts/invocation.gd
+++ b/Fight/Scripts/invocation.gd
@@ -3,7 +3,7 @@ class_name Invocation
 
 
 var invocateur
-var is_mort: bool
+
 @onready var hitbox: Area2D = $Area2D
 
 
@@ -154,12 +154,14 @@ func debut_tour():
 	if check_etats(["PETRIFIE"]):
 		combat.passe_tour()
 	joue_ia()
-	combat.passe_tour()
+	if not is_mort:
+		combat.passe_tour()
 
 
 func chemin_vers_proche() -> Array:
 	var voisins = [Vector2i(-1, 0), Vector2i(1, 0), Vector2i(0, -1), Vector2i(0, 1)]
 	var min_dist = 99999999
+	var min_hp = 9999999
 	var min_chemin = []
 	for combattant in combat.combattants:
 		if combattant.equipe != equipe:
@@ -170,6 +172,11 @@ func chemin_vers_proche() -> Array:
 				if len(chemin) < min_dist and len(chemin) > 0:
 					min_dist = len(chemin)
 					min_chemin = chemin
+					min_hp = combattant.stats.hp
+				elif len(chemin) == min_dist and len(chemin) > 0:
+					min_dist = len(chemin)
+					min_chemin = chemin
+					min_hp = combattant.stats.hp
 	return min_chemin
 
 
@@ -198,11 +205,12 @@ func joue_ia():
 	combat.check_morts()
 	if is_mort:
 		return
-	var chemin = chemin_vers_proche()
-	if len(chemin) > stats.pm + 1:
-		chemin = chemin.slice(0, stats.pm + 1)
-	if len(chemin) > 0:
-		deplace_perso(chemin)
+	if stats.pm > 0:
+		var chemin = chemin_vers_proche()
+		if len(chemin) > stats.pm + 1:
+			chemin = chemin.slice(0, stats.pm + 1)
+		if len(chemin) > 0:
+			deplace_perso(chemin)
 	for sort in sorts:
 		if not sort.precheck_cast(self):
 			continue
@@ -242,7 +250,7 @@ func meurt():
 				new_effets.append(effet)
 		combattant.effets = new_effets
 	
-	if classe in ["Bombe_Incendiaire", "Bombe_A_Eau"]:
+	if classe in ["Bombe_Incendiaire", "Bombe_A_Eau"] and stats.hp <= 0:
 		var sort = sorts[0]
 		zone = combat.tilemap.get_zone(
 			grid_pos,

--- a/Fight/Scripts/map.gd
+++ b/Fight/Scripts/map.gd
@@ -147,6 +147,8 @@ func update_mort_subite(tour: int):
 				if combattant.grid_pos == Vector2i(cell_pos) + offset:
 					combattant.stats.hp = 0
 			combat.check_morts()
+			if combat.etat == 3:
+				return
 	combat.check_morts()
 	build_grids()
 	for combattant in combat.combattants:

--- a/Fight/combat.tscn
+++ b/Fight/combat.tscn
@@ -67,7 +67,6 @@ offset_right = 129.0
 offset_bottom = 681.0
 
 [node name="Fleche0" type="TextureButton" parent="OrientationControls"]
-layout_mode = 0
 offset_left = 33.0
 offset_right = 142.0
 offset_bottom = 70.0
@@ -76,7 +75,6 @@ texture_normal = ExtResource("10_mc0eu")
 texture_pressed = ExtResource("11_4niei")
 
 [node name="Fleche1" type="TextureButton" parent="OrientationControls"]
-layout_mode = 0
 offset_left = 33.0
 offset_top = 21.0
 offset_right = 142.0
@@ -86,7 +84,6 @@ texture_normal = ExtResource("12_toemx")
 texture_pressed = ExtResource("13_ffdov")
 
 [node name="Fleche2" type="TextureButton" parent="OrientationControls"]
-layout_mode = 0
 offset_top = 21.0
 offset_right = 109.0
 offset_bottom = 91.0
@@ -95,7 +92,6 @@ texture_normal = ExtResource("14_7ic16")
 texture_pressed = ExtResource("15_rvv21")
 
 [node name="Fleche3" type="TextureButton" parent="OrientationControls"]
-layout_mode = 0
 offset_right = 109.0
 offset_bottom = 70.0
 scale = Vector2(0.3, 0.3)
@@ -121,7 +117,6 @@ offset_right = 40.0
 offset_bottom = 40.0
 
 [node name="TexteFin" type="Label" parent="AffichageFin"]
-layout_mode = 0
 offset_left = 640.0
 offset_top = 228.0
 offset_right = 959.0
@@ -133,7 +128,6 @@ horizontal_alignment = 1
 vertical_alignment = 1
 
 [node name="BoutonRetour" type="TextureButton" parent="AffichageFin"]
-layout_mode = 0
 offset_left = 735.0
 offset_top = 501.0
 offset_right = 865.0

--- a/Fight/combat.tscn
+++ b/Fight/combat.tscn
@@ -67,6 +67,7 @@ offset_right = 129.0
 offset_bottom = 681.0
 
 [node name="Fleche0" type="TextureButton" parent="OrientationControls"]
+layout_mode = 0
 offset_left = 33.0
 offset_right = 142.0
 offset_bottom = 70.0
@@ -75,6 +76,7 @@ texture_normal = ExtResource("10_mc0eu")
 texture_pressed = ExtResource("11_4niei")
 
 [node name="Fleche1" type="TextureButton" parent="OrientationControls"]
+layout_mode = 0
 offset_left = 33.0
 offset_top = 21.0
 offset_right = 142.0
@@ -84,6 +86,7 @@ texture_normal = ExtResource("12_toemx")
 texture_pressed = ExtResource("13_ffdov")
 
 [node name="Fleche2" type="TextureButton" parent="OrientationControls"]
+layout_mode = 0
 offset_top = 21.0
 offset_right = 109.0
 offset_bottom = 91.0
@@ -92,6 +95,7 @@ texture_normal = ExtResource("14_7ic16")
 texture_pressed = ExtResource("15_rvv21")
 
 [node name="Fleche3" type="TextureButton" parent="OrientationControls"]
+layout_mode = 0
 offset_right = 109.0
 offset_bottom = 70.0
 scale = Vector2(0.3, 0.3)
@@ -117,6 +121,7 @@ offset_right = 40.0
 offset_bottom = 40.0
 
 [node name="TexteFin" type="Label" parent="AffichageFin"]
+layout_mode = 0
 offset_left = 640.0
 offset_top = 228.0
 offset_right = 959.0
@@ -128,6 +133,7 @@ horizontal_alignment = 1
 vertical_alignment = 1
 
 [node name="BoutonRetour" type="TextureButton" parent="AffichageFin"]
+layout_mode = 0
 offset_left = 735.0
 offset_top = 501.0
 offset_right = 865.0

--- a/Fight/combattant.tscn
+++ b/Fight/combattant.tscn
@@ -7,9 +7,9 @@
 [ext_resource type="Texture2D" uid="uid://di4dh5dwn3exu" path="res://Fight/Images/hp_display.png" id="5_o5476"]
 [ext_resource type="PackedScene" uid="uid://wjqjfqvfle7s" path="res://Fight/stats_perdu.tscn" id="6_xhp4k"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_nkrbs"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_r4oqq"]
 
-[sub_resource type="LabelSettings" id="LabelSettings_tr7w4"]
+[sub_resource type="LabelSettings" id="LabelSettings_dng0c"]
 font_size = 25
 
 [node name="Combattant" type="Node2D"]
@@ -32,7 +32,7 @@ position = Vector2(0, -38)
 scale = Vector2(2, 4)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-shape = SubResource("RectangleShape2D_nkrbs")
+shape = SubResource("RectangleShape2D_r4oqq")
 
 [node name="HP" type="Sprite2D" parent="."]
 visible = false
@@ -48,7 +48,7 @@ offset_top = -18.0
 offset_right = 49.0
 offset_bottom = 20.0
 text = "0/0"
-label_settings = SubResource("LabelSettings_tr7w4")
+label_settings = SubResource("LabelSettings_dng0c")
 horizontal_alignment = 1
 vertical_alignment = 1
 

--- a/Fight/combattant.tscn
+++ b/Fight/combattant.tscn
@@ -7,9 +7,9 @@
 [ext_resource type="Texture2D" uid="uid://di4dh5dwn3exu" path="res://Fight/Images/hp_display.png" id="5_o5476"]
 [ext_resource type="PackedScene" uid="uid://wjqjfqvfle7s" path="res://Fight/stats_perdu.tscn" id="6_xhp4k"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_3si82"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_nkrbs"]
 
-[sub_resource type="LabelSettings" id="LabelSettings_giky8"]
+[sub_resource type="LabelSettings" id="LabelSettings_tr7w4"]
 font_size = 25
 
 [node name="Combattant" type="Node2D"]
@@ -32,7 +32,7 @@ position = Vector2(0, -38)
 scale = Vector2(2, 4)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-shape = SubResource("RectangleShape2D_3si82")
+shape = SubResource("RectangleShape2D_nkrbs")
 
 [node name="HP" type="Sprite2D" parent="."]
 visible = false
@@ -48,7 +48,7 @@ offset_top = -18.0
 offset_right = 49.0
 offset_bottom = 20.0
 text = "0/0"
-label_settings = SubResource("LabelSettings_giky8")
+label_settings = SubResource("LabelSettings_tr7w4")
 horizontal_alignment = 1
 vertical_alignment = 1
 

--- a/Fight/invocation.tscn
+++ b/Fight/invocation.tscn
@@ -7,9 +7,9 @@
 [ext_resource type="Texture2D" uid="uid://di4dh5dwn3exu" path="res://Fight/Images/hp_display.png" id="5_eb3vf"]
 [ext_resource type="PackedScene" uid="uid://wjqjfqvfle7s" path="res://Fight/stats_perdu.tscn" id="6_aopma"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_1g144"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_7wk3d"]
 
-[sub_resource type="LabelSettings" id="LabelSettings_7rdv5"]
+[sub_resource type="LabelSettings" id="LabelSettings_ax56n"]
 font_size = 25
 
 [node name="Invocation" type="Node2D"]
@@ -30,7 +30,7 @@ position = Vector2(0, -10)
 scale = Vector2(2, 2)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-shape = SubResource("RectangleShape2D_1g144")
+shape = SubResource("RectangleShape2D_7wk3d")
 
 [node name="HP" type="Sprite2D" parent="."]
 visible = false
@@ -46,7 +46,7 @@ offset_top = -18.0
 offset_right = 49.0
 offset_bottom = 5.0
 text = "40/40"
-label_settings = SubResource("LabelSettings_7rdv5")
+label_settings = SubResource("LabelSettings_ax56n")
 horizontal_alignment = 1
 vertical_alignment = 1
 

--- a/Fight/invocation.tscn
+++ b/Fight/invocation.tscn
@@ -7,9 +7,9 @@
 [ext_resource type="Texture2D" uid="uid://di4dh5dwn3exu" path="res://Fight/Images/hp_display.png" id="5_eb3vf"]
 [ext_resource type="PackedScene" uid="uid://wjqjfqvfle7s" path="res://Fight/stats_perdu.tscn" id="6_aopma"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_7wk3d"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_0o6we"]
 
-[sub_resource type="LabelSettings" id="LabelSettings_ax56n"]
+[sub_resource type="LabelSettings" id="LabelSettings_ihqpi"]
 font_size = 25
 
 [node name="Invocation" type="Node2D"]
@@ -30,7 +30,7 @@ position = Vector2(0, -10)
 scale = Vector2(2, 2)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-shape = SubResource("RectangleShape2D_7wk3d")
+shape = SubResource("RectangleShape2D_0o6we")
 
 [node name="HP" type="Sprite2D" parent="."]
 visible = false
@@ -46,7 +46,7 @@ offset_top = -18.0
 offset_right = 49.0
 offset_bottom = 5.0
 text = "40/40"
-label_settings = SubResource("LabelSettings_ax56n")
+label_settings = SubResource("LabelSettings_ihqpi")
 horizontal_alignment = 1
 vertical_alignment = 1
 

--- a/Jeu/sort.gd
+++ b/Jeu/sort.gd
@@ -188,7 +188,7 @@ func parse_effets(lanceur, p_cible, p_effets, critique, centre, aoe):
 					p_cible = combattant
 		var combattant_effet = p_effets.duplicate(true)
 		var new_effet = Effet.new(lanceur, p_cible, effet, combattant_effet[effet], critique, centre, aoe, self)
-		if new_effet.instant:
+		if new_effet.instant and p_cible.stats.hp > 0:
 			new_effet.execute()
 		if new_effet.duree > 0:
 			p_cible.effets.append(new_effet)
@@ -254,7 +254,37 @@ func check_cible(lanceur, case_cible) -> bool:
 	return true
 
 
-func from_arme(_combattant, arme):
+func from_arme(combattant, arme):
+	var element_principal = "DOMMAGE_FIXE"
+	match combattant.classe:
+		"Cra":
+			element_principal = "DOMMAGE_AIR"
+		"Eca":
+			element_principal = "DOMMAGE_AIR"
+		"Eni":
+			element_principal = "DOMMAGE_FEU"
+		"Enu":
+			element_principal = "DOMMAGE_EAU"
+		"Feca":
+			element_principal = "DOMMAGE_EAU"
+		"Iop":
+			element_principal = "DOMMAGE_TERRE"
+		"Osa":
+			element_principal = "DOMMAGE_FEU"
+		"Panda":
+			element_principal = "DOMMAGE_FEU"
+		"Roublard":
+			element_principal = "DOMMAGE_EAU"
+		"Sacrieur":
+			element_principal = "DOMMAGE_TERRE"
+		"Sadida":
+			element_principal = "DOMMAGE_TERRE"
+		"Sram":
+			element_principal = "DOMMAGE_AIR"
+		"Xelor":
+			element_principal = "DOMMAGE_FEU"
+		"Zobal":
+			element_principal = "DOMMAGE_EAU"
 	if not arme.is_empty():
 		var data = GlobalData.equipements[arme].to_json()
 		pa = data["pa"]
@@ -269,7 +299,7 @@ func from_arme(_combattant, arme):
 		type_zone = GlobalData.TypeZone.CERCLE
 		taille_zone = Vector2(0, 0)
 		po_modifiable = 0
-		effets = { "DOMMAGE_FIXE": { "base": { "valeur": 5 }, "critique": { "valeur": 7 } } }
+		effets = {element_principal:{"base":{"valeur":5},"critique":{"valeur":7}}}
 	nom = "arme"
 	ldv = 1
 	return self

--- a/Jeu/sort.gd
+++ b/Jeu/sort.gd
@@ -66,7 +66,7 @@ func execute_effets(lanceur, cases_cibles, centre) -> bool:
 	var aoe = false
 	if len(cases_cibles) == 0:
 		return false
-	if len(cases_cibles) > 1:
+	if len(cases_cibles) > 1 or taille_zone.y > 0:
 		aoe = true
 	print(lanceur.classe, "_", str(lanceur.id), " lance ", nom, ".")
 	var combattants = lanceur.combat.combattants


### PR DESCRIPTION
- Lors de la mort subite, la détection de victoire s'effectue correctement
- Les cases bonus ne sont plus doublées après le tour 15 si la mort subite n'est pas activée
- Les effets des cases bonus ne sont plus débuffables
- La Célestine n'augmente plus les soins reçus par la case bonus de soin
- Les invocations priorisent les déplacements vers les personnages avec le moins de PdV
- Coup de bambou n'est plus actif lors du tour suivant du Pandawa
- Roulette n'inflige plus de dégats à son lanceur lorsque le sort est utilisé
- Si un personnage meurt, la transposition n'est plus effectuée
- Un personnage immobilisé est maintenant réduit à 0 PM
- Le vol de vie rend désormais 100% des dégats infligés
- Les coups de poing font maintenant des dégats élémentaires et bénéficient du bonus d'orientation
- Les bombes du Roublard n'explosent plus à la mort de leur invocateur
- La mort naturelle d'une bombe ne fait plus passer le tour du personnage suivant
- Un personnage ne peut plus être taclé en descendant d'un Pandawa
- Un Pandawa en train de porter un personnage ne peut plus être transposé
- Tout ou rien soigne bien les personnages sacrifiés
- Les stats de la cible sont bien mises à jour lors de la transposition d'un Sacrifice
- Les effets affectant des groupes de combattants sont désormais appliqués même si le personnage est porté
- La mort d'un Pandawa portant un personnage ne brise plus les grilles de calcul
- Les invocations statiques ne peuvent plus se déplacer avec des PM
- Les PM négatifs ne font plus planter le pathfinding